### PR TITLE
Fixed typo "embeeded" => "embedded"

### DIFF
--- a/basic/qml/main.go
+++ b/basic/qml/main.go
@@ -27,7 +27,7 @@ func main() {
 	// create the qml application engine
 	engine := qml.NewQQmlApplicationEngine(nil)
 
-	// load the embeeded qml file
+	// load the embedded qml file
 	// created by either qtrcc or qtdeploy
 	engine.Load(core.NewQUrl3("qrc:/qml/main.qml", 0))
 	// you can also load a local file like this instead:

--- a/basic/quick/main.go
+++ b/basic/quick/main.go
@@ -33,7 +33,7 @@ func main() {
 	view.SetResizeMode(quick.QQuickView__SizeRootObjectToView)
 	view.SetTitle("Hello QML/Quick Example")
 
-	// load the embeeded qml file
+	// load the embedded qml file
 	// created by either qtrcc or qtdeploy
 	view.SetSource(core.NewQUrl3("qrc:/qml/main.qml", 0))
 	// you can also load a local file like this instead:


### PR DESCRIPTION
A simple typo fix.